### PR TITLE
Prevent duplicate data on site refresh during processing

### DIFF
--- a/src/groovy/de/hbznrw/ygor/bridges/ZdbBridge.groovy
+++ b/src/groovy/de/hbznrw/ygor/bridges/ZdbBridge.groovy
@@ -6,7 +6,6 @@ import groovy.util.logging.Log4j
 import de.hbznrw.ygor.connectors.*
 import de.hbznrw.ygor.enums.*
 import de.hbznrw.ygor.interfaces.*
-import de.hbznrw.ygor.export.structure.TitleStruct
 import org.codehaus.groovy.runtime.DefaultGroovyMethods
 
 @Log4j


### PR DESCRIPTION
@hornmo Couldn't reproduce the issue. Anyway, EnrichmentController.processFile() now checks the ProcessingState. Only if ProcessingState is not already `WORKING`, the enrichment processing (`en.process`) is triggered.

Please excuse the re-formatting. EnrichmentController line 122 is the relevant one.