### PR TITLE
Remove fixed default value 'fulltext' for coverageDepth (ERMS-3213)

### DIFF
--- a/src/java/resources/YgorFieldKeyMapping.json
+++ b/src/java/resources/YgorFieldKeyMapping.json
@@ -72,9 +72,6 @@
     },
     "order" : ["kbart"],
     "type" : "String",
-    "value" : {
-      "fixed" : "Fulltext"
-    },
     "flags" : {
       "valid" : [{"serial" : "ok", "monograph" : "ok", "other" : "ok"}],
       "invalid" : [{"serial" : "error", "monograph" : "error", "other" : "ok"}],


### PR DESCRIPTION
please review - but do not merge, yet. Thanks.